### PR TITLE
Remove reading from php://input

### DIFF
--- a/Listener/GitHubHookControllerSubscriber.php
+++ b/Listener/GitHubHookControllerSubscriber.php
@@ -103,11 +103,7 @@ class GitHubHookControllerSubscriber implements EventSubscriberInterface
             return;
         }
 
-        // Rewriting the php://input stream into a temp stream allow us to read the request body multiple times
-        $bodyStream = new Stream('php://temp', 'wb+');
-        $bodyStream->write(file_get_contents('php://input'));
-
-        $psr7Request = $this->messageFactory->createRequest($request)->withBody($bodyStream);
+        $psr7Request = $this->messageFactory->createRequest($request);
 
         $eventType            = $request->headers->get('X-GitHub-Event');
         $mappedConfigurations = $this->mapConfigurations($configurations);

--- a/Tests/Listener/GitHubHookControllerSubscriberTest.php
+++ b/Tests/Listener/GitHubHookControllerSubscriberTest.php
@@ -105,7 +105,6 @@ class GitHubHookControllerSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getController()->shouldNotBeCalled();
 
         $initialPsrRequest = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
-        $initialPsrRequest->withBody(Argument::any())->shouldBeCalled()->willReturn($initialPsrRequest);
 
         $this->messageFactory->createRequest($request)->shouldBeCalled()->willReturn($initialPsrRequest);
 


### PR DESCRIPTION
Hey!

I ran into issues with php://input being empty during unit tests. Removing the code makes it fall back to Diactoros` createRequest method which reads:

```
...
        if (PHP_VERSION_ID < 50600) {
            $body = new DiactorosStream('php://temp', 'wb+');
            $body->write($symfonyRequest->getContent());
        } else {
            $body = new DiactorosStream($symfonyRequest->getContent(true));
        }
...
```

Looks good to me :)